### PR TITLE
Prevent absolute path resolution

### DIFF
--- a/zio-http-gen-sbt-plugin/src/main/scala/zio/http/gen/sbt/ZioHttpCodegen.scala
+++ b/zio-http-gen-sbt-plugin/src/main/scala/zio/http/gen/sbt/ZioHttpCodegen.scala
@@ -113,7 +113,7 @@ object ZioHttpCodegen extends AutoPlugin {
           CodeGen
             .renderedFiles(codegenEndpoints, basePackageParts.mkString("."))
             .map { case (path, content) =>
-              val filePath = currentTargetPat.resolve(path)
+              val filePath = currentTargetPat.resolve(path.stripPrefix("/"))
               s.log.debug(s"OpenAPI: creating file ${filePath.toString} ($path)")
               Files.createDirectories(filePath.getParent)
               Files.write(filePath, content.getBytes(StandardCharsets.UTF_8), CREATE, TRUNCATE_EXISTING)

--- a/zio-http-gen-sbt-plugin/src/sbt-test/zio-http-sbt-codegen/simple/src/main/oapi/dev/school/service/openapi.yaml
+++ b/zio-http-gen-sbt-plugin/src/sbt-test/zio-http-sbt-codegen/simple/src/main/oapi/dev/school/service/openapi.yaml
@@ -1,0 +1,31 @@
+openapi: 3.0.3
+info:
+  title: School Service
+  version: 0.0.1
+servers:
+  - url: https://school.example.org/api/v1/school
+paths:
+  # test that code generation works well for single-segment paths
+  /teachers:
+    get:
+      summary: Get a list of all teachers
+      responses:
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Teacher'
+components:
+  schemas:
+    Teacher:
+      type: object
+      properties:
+        name:
+          type: string
+          description: Full name
+        room:
+          type: string
+          description: Room number

--- a/zio-http-gen-sbt-plugin/src/sbt-test/zio-http-sbt-codegen/simple/test
+++ b/zio-http-gen-sbt-plugin/src/sbt-test/zio-http-sbt-codegen/simple/test
@@ -4,3 +4,5 @@
 > compile
 $ exists target/scala-2.13/classes/dev/zoo/service/api/v1/zoo/Animal.class
 $ exists target/scala-2.13/classes/dev/zoo/service/component/Animal.class
+$ exists target/scala-2.13/classes/dev/school/service/Teachers.class
+$ exists target/scala-2.13/classes/dev/school/service/component/Teacher.class


### PR DESCRIPTION
Having this plugin enabled and an OpenAPI spec in `src/main/oapi/my_namespace/my_openapi_spec.yaml`, `sbt compile` crashes while attempting to create a file in the system root directory (like `/Pet.scala`). Upon investigation it turned out to be a file with `Endpoint` definitions.

This PR adds more logging and fixes the issue.

(I'm not 100% sure this is the right place to fix the issue. If a better place is somewhere upstream in zio-http-gen, please consider this PR simply a bug report in code form.)